### PR TITLE
Replace 127.0.0.1 with 0.0.0.0 all interface that possible exist in t…

### DIFF
--- a/examples/http_server/src/main.rs
+++ b/examples/http_server/src/main.rs
@@ -57,7 +57,7 @@ fn handle_client(mut stream: TcpStream) -> std::io::Result<()> {
 fn main() -> std::io::Result<()> {
     let port = std::env::var("PORT").unwrap_or(1234.to_string());
     println!("new connection at {}", port);
-    let listener = TcpListener::bind(format!("127.0.0.1:{}", port))?;
+    let listener = TcpListener::bind(format!("0.0.0.0:{}", port))?;
     loop {
         let _ = handle_client(listener.accept()?.0);
     }


### PR DESCRIPTION
remove static 127 interface with what ever the crio network generate at the runtime. 

Signed-off-by: Alex Lau (AvengerMoJo) <avengermojo@gmail.com>