### PR TITLE
[Lib] Add sock_getpeeraddr method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmedge_wasi_socket"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "Yi <yi@secondstate.io>" ]
 edition = "2018"
 license = "Apache-2.0"

--- a/examples/tcp_listener.rs
+++ b/examples/tcp_listener.rs
@@ -1,11 +1,13 @@
 use std::io::{Read, Write};
+use std::net::SocketAddr;
 
 #[cfg(feature = "std")]
 use std::net::{Shutdown, TcpListener, TcpStream};
 #[cfg(not(feature = "std"))]
 use wasmedge_wasi_socket::{Shutdown, TcpListener, TcpStream};
 
-fn handle_client(mut stream: TcpStream) -> std::io::Result<()> {
+fn handle_client((mut stream, addr): (TcpStream, SocketAddr)) -> std::io::Result<()> {
+    println!("get connection from {}", addr.to_string());
     let mut buf = String::new();
     stream.read_to_string(&mut buf)?;
     println!("get message: {}", buf);
@@ -18,7 +20,7 @@ fn handle_client(mut stream: TcpStream) -> std::io::Result<()> {
 
 fn main() -> std::io::Result<()> {
     let port = std::env::var("PORT").unwrap_or(1234.to_string());
-    println!("new connection at {}", port);
+    println!("listening at 127.0.0.1:{}", port);
     let listener = TcpListener::bind(format!("127.0.0.1:{}", port))?;
-    handle_client(listener.accept()?.0)
+    handle_client(listener.accept()?)
 }


### PR DESCRIPTION
Add sock_getpeeraddr method for TcpStream. In the meantime, some
attributes like Clone, Copy and Debug are added to structs. Also passed
clippy check.

Signed-off-by: KernelErr <45716019+KernelErr@users.noreply.github.com>