### PR TITLE
[Lib]: Add From<Socket> for TcpStream.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,12 @@ impl Write for &TcpStream {
     }
 }
 
+impl From<socket::Socket> for TcpStream {
+    fn from(s: socket::Socket) -> Self {
+        TcpStream { s }
+    }
+}
+
 impl TcpListener {
     /// Create TCP socket and bind to the given address.
     ///
@@ -274,7 +280,7 @@ pub fn nslookup(node: &str, service: &str) -> std::io::Result<Vec<SocketAddr>> {
         }
 
         let addr = match sockaddr.family {
-            #[cfg(feature="wasmedge_0_10")]
+            #[cfg(feature = "wasmedge_0_10")]
             socket::AddressFamily::Unspec => {
                 //unimplemented!("not support unspec")
                 continue;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,6 +1,7 @@
 use crate::wasi_poll as poll;
 use std::os::wasi::prelude::*;
 
+#[derive(Clone)]
 pub enum Subscription {
     Timeout {
         userdata: u64,


### PR DESCRIPTION
Changes:
1. Implement From<Socket> for TcpStream, this allows `wasmedge_wasi_socket` to be merged into `rust-mysql-simple`.
2. Make Subscription derive Clone, this allows outer crates to use it easily.

Signed-off-by: Tricster <mediosrity@qq.com>