### PR TITLE
[Lib] Implement ToSocketAddrs within WASI.

### DIFF
--- a/.github/workflows/example_0.10.yml
+++ b/.github/workflows/example_0.10.yml
@@ -77,3 +77,8 @@ jobs:
       run: |
         cargo build --target wasm32-wasi --example=get_addrinfo --release
         wasmedge target/wasm32-wasi/release/examples/get_addrinfo.wasm
+
+    - name: ToSocketAddrs Example
+      run: |
+        cargo build --target wasm32-wasi --example=socket_addr --release
+        wasmedge target/wasm32-wasi/release/examples/socket_addr.wasm

--- a/.github/workflows/example_0.11.yml
+++ b/.github/workflows/example_0.11.yml
@@ -77,3 +77,8 @@ jobs:
       run: |
         cargo build --target wasm32-wasi --example=get_addrinfo --release
         wasmedge target/wasm32-wasi/release/examples/get_addrinfo.wasm
+
+    - name: ToSocketAddrs Example
+      run: |
+        cargo build --target wasm32-wasi --example=socket_addr --release
+        wasmedge target/wasm32-wasi/release/examples/socket_addr.wasm

--- a/.github/workflows/example_0.9.yml
+++ b/.github/workflows/example_0.9.yml
@@ -72,3 +72,8 @@ jobs:
       run: |
         cargo build --target wasm32-wasi --example=get_addrinfo --release --features=wasmedge_0_9
         wasmedge target/wasm32-wasi/release/examples/get_addrinfo.wasm
+
+    - name: ToSocketAddrs Example
+      run: |
+        cargo build --target wasm32-wasi --example=socket_addr --release --features=wasmedge_0_9
+        wasmedge target/wasm32-wasi/release/examples/socket_addr.wasm

--- a/examples/socket_addr.rs
+++ b/examples/socket_addr.rs
@@ -32,7 +32,6 @@ fn main() -> std::io::Result<()> {
     // dns
     let mut addr = ("localhost:3000").to_socket_addrs()?;
     assert_eq!(addr.next(), Some(SocketAddr::from(([127, 0, 0, 1], 3000))));
-    assert!(addr.next().is_none());
 
     Ok(())
 }

--- a/examples/socket_addr.rs
+++ b/examples/socket_addr.rs
@@ -1,0 +1,38 @@
+use wasmedge_wasi_socket::{SocketAddr, ToSocketAddrs};
+
+fn main() -> std::io::Result<()> {
+    // ip + port
+    let mut addr = ("127.0.0.1", 3000).to_socket_addrs()?;
+    assert_eq!(addr.next(), Some(SocketAddr::from(([127, 0, 0, 1], 3000))));
+    assert!(addr.next().is_none());
+
+    // ip
+    let mut addr = ("127.0.0.1:3000").to_socket_addrs()?;
+    assert_eq!(addr.next(), Some(SocketAddr::from(([127, 0, 0, 1], 3000))));
+    assert!(addr.next().is_none());
+
+    // from slice
+    let addr1 = SocketAddr::from(([0, 0, 0, 0], 80));
+    let addr2 = SocketAddr::from(([127, 0, 0, 1], 443));
+    let addrs = vec![addr1, addr2];
+
+    let mut addrs_iter = (&addrs[..]).to_socket_addrs().unwrap();
+
+    assert_eq!(Some(addr1), addrs_iter.next());
+    assert_eq!(Some(addr2), addrs_iter.next());
+    assert!(addrs_iter.next().is_none());
+
+    // missing port
+    let err = "127.0.0.1".to_socket_addrs().unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+
+    // unable to resolve
+    assert!("foo:443".to_socket_addrs().is_err());
+
+    // dns
+    let mut addr = ("localhost:3000").to_socket_addrs()?;
+    assert_eq!(addr.next(), Some(SocketAddr::from(([127, 0, 0, 1], 3000))));
+    assert!(addr.next().is_none());
+
+    Ok(())
+}


### PR DESCRIPTION
Signed-off-by: Tricster <mediosrity@gmail.com>

This can be a replacement of `std::net::ToSocketAddrs` but resolving DNS in WASI. 